### PR TITLE
Remove express deprecation warnings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,23 @@
 import get from 'lodash.get'
 
+const getAcceptedLanguage = (request = {}) => {
+  if (typeof request.get !== 'function') {
+    return
+  }
+
+  const header = request.get('accept-language') || ''
+  const acceptedLanguages = header.split(';')
+
+  return acceptedLanguages[0]
+}
+
 export const getLocaleFromRequest = options => request => {
   const cookieName = get(options, 'cookieName', 'locale')
 
   const locale = (
     decodeURIComponent(get(request, 'query.locale', '')) ||
     get(request, ['cookies', cookieName]) ||
-    get(request, 'headers.accept-language', '').split(';')[0] ||
+    getAcceptedLanguage(request) ||
     get(request, 'acceptedLanguages') ||
     get(request, 'hostname.locale')
   )

--- a/src/spec.js
+++ b/src/spec.js
@@ -21,8 +21,11 @@ describe('The `getLocaleFromRequest` helper', () => {
     expect(actual).toEqual(expected)
   })
 
-  it('should return headers.accept-language from request if any', () => {
-    const actual = getLocaleFromRequest()({ headers: { 'accept-language': 'foo' } })
+  it('should return `accept-language` header from request if any', () => {
+    const mockedRequest = {
+      get: headerKey => ({ 'accept-language': 'foo' }[headerKey])
+    }
+    const actual = getLocaleFromRequest()(mockedRequest)
     const expected = 'foo'
 
     expect(actual).toEqual(expected)
@@ -44,12 +47,13 @@ describe('The `getLocaleFromRequest` helper', () => {
   })
 
   it('should respect priority order', () => {
+    const mockedRequest = headerKey => ({ 'accept-language': '3' }[headerKey])
     const options = { cookieName: 'cookieLocale' }
 
     let actual = getLocaleFromRequest(options)({
       query: { locale: '1' },
       cookies: { cookieLocale: '2' },
-      headers: { 'accept-language': '3' },
+      get: mockedRequest,
       acceptedLanguages: '4',
       hostname: { locale: '5' }
     })
@@ -58,7 +62,7 @@ describe('The `getLocaleFromRequest` helper', () => {
 
     actual = getLocaleFromRequest(options)({
       cookies: { cookieLocale: '2' },
-      headers: { 'accept-language': '3' },
+      get: mockedRequest,
       acceptedLanguages: '4',
       hostname: { locale: '5' }
     })
@@ -66,7 +70,7 @@ describe('The `getLocaleFromRequest` helper', () => {
     expect(actual).toEqual(expected)
 
     actual = getLocaleFromRequest(options)({
-      headers: { 'accept-language': '3' },
+      get: mockedRequest,
       acceptedLanguages: '4',
       hostname: { locale: '5' }
     })


### PR DESCRIPTION
Maybe we should also add a peerDependency to express 4+ in the package.json?